### PR TITLE
Fix flaky test associated w/ sampling

### DIFF
--- a/tests/integration/test_ctgan.py
+++ b/tests/integration/test_ctgan.py
@@ -52,13 +52,13 @@ def test_ctgan_numpy():
 
 
 def test_log_frequency():
-    with patch('numpy.random.choice', 
-               return_value = np.repeat(['a', 'b', 'c'], [950, 25, 25])):
+    with patch('numpy.random.choice',
+               return_value=np.repeat(['a', 'b', 'c'], [950, 25, 25])):
         data = pd.DataFrame({
             'continuous': np.random.random(1000),
             'discrete': np.random.choice(['a', 'b', 'c'], 1000, p=[0.95, 0.025, 0.025])
         })
-    
+
     discrete_columns = ['discrete']
 
     ctgan = CTGANSynthesizer()

--- a/tests/integration/test_ctgan.py
+++ b/tests/integration/test_ctgan.py
@@ -64,13 +64,13 @@ def test_log_frequency():
     ctgan = CTGANSynthesizer()
     ctgan.fit(data, discrete_columns, epochs=100)
 
-    sampled = ctgan.sample(1000)
+    sampled = ctgan.sample(10000)
     counts = sampled['discrete'].value_counts()
-    assert counts['a'] < 650
+    assert counts['a'] < 6500
 
     ctgan = CTGANSynthesizer()
     ctgan.fit(data, discrete_columns, epochs=100, log_frequency=False)
 
-    sampled = ctgan.sample(1000)
+    sampled = ctgan.sample(10000)
     counts = sampled['discrete'].value_counts()
-    assert counts['a'] > 900
+    assert counts['a'] > 9000

--- a/tests/integration/test_ctgan.py
+++ b/tests/integration/test_ctgan.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 
 from ctgan.synthesizer import CTGANSynthesizer
+from unittest.mock import patch
 
 
 def test_ctgan_dataframe():
@@ -51,11 +52,13 @@ def test_ctgan_numpy():
 
 
 def test_log_frequency():
-    data = pd.DataFrame({
-        'continuous': np.random.random(1000),
-        'discrete': np.random.choice(['a', 'b', 'c'], 1000, p=[0.95, 0.025, 0.025])
-    })
-
+    with patch('numpy.random.choice', 
+               return_value = np.repeat(['a', 'b', 'c'], [950, 25, 25])):
+        data = pd.DataFrame({
+            'continuous': np.random.random(1000),
+            'discrete': np.random.choice(['a', 'b', 'c'], 1000, p=[0.95, 0.025, 0.025])
+        })
+    
     discrete_columns = ['discrete']
 
     ctgan = CTGANSynthesizer()

--- a/tests/integration/test_ctgan.py
+++ b/tests/integration/test_ctgan.py
@@ -9,8 +9,6 @@ but correctness of the data values and the internal behavior of the
 model are not checked.
 """
 
-from unittest.mock import patch
-
 import numpy as np
 import pandas as pd
 
@@ -53,12 +51,11 @@ def test_ctgan_numpy():
 
 
 def test_log_frequency():
-    with patch('numpy.random.choice',
-               return_value=np.repeat(['a', 'b', 'c'], [950, 25, 25])):
-        data = pd.DataFrame({
-            'continuous': np.random.random(1000),
-            'discrete': np.random.choice(['a', 'b', 'c'], 1000, p=[0.95, 0.025, 0.025])
-        })
+
+    data = pd.DataFrame({
+        'continuous': np.random.random(1000),
+        'discrete': np.repeat(['a', 'b', 'c'], [950, 25, 25])
+    })
 
     discrete_columns = ['discrete']
 

--- a/tests/integration/test_ctgan.py
+++ b/tests/integration/test_ctgan.py
@@ -9,11 +9,12 @@ but correctness of the data values and the internal behavior of the
 model are not checked.
 """
 
+from unittest.mock import patch
+
 import numpy as np
 import pandas as pd
 
 from ctgan.synthesizer import CTGANSynthesizer
-from unittest.mock import patch
 
 
 def test_ctgan_dataframe():


### PR DESCRIPTION
This change attempts to fix https://github.com/sdv-dev/CTGAN/issues/22 by
1. Make the training data generation of the categorical variable deterministic
2. Increasing the number of samples synthesized by the trained model for calculating proportions of levels

@csala