### PR TITLE
Nan loss

### DIFF
--- a/ctgan/synthesizer.py
+++ b/ctgan/synthesizer.py
@@ -48,20 +48,26 @@ class CTGANSynthesizer(object):
 
     @staticmethod
     def _gumbel_softmax(logits, tau=1, hard=False, eps=1e-10, dim=-1):
-        """Deals with the instability of the gumbel_softmax for older versions of torch
+        """Deals with the instability of the gumbel_softmax for older versions of torch.
+
+           For more details about the issue: 
            https://drive.google.com/file/d/1AA5wPfZ1kquaRtVruCd6BiYZGcDeNxyP/view?usp=sharing
 
         Args:
-            logits: […, num_features] unnormalized log probabilities
-            tau: non-negative scalar temperature
-            hard: if True, the returned samples will be discretized as one-hot vectors,
-                  but will be differentiated as if it is the soft sample in autograd
-            dim (int): A dimension along which softmax will be computed. Default: -1.
+            logits:
+                […, num_features] unnormalized log probabilities
+            tau:
+                non-negative scalar temperature
+            hard:
+                if True, the returned samples will be discretized as one-hot vectors,
+                but will be differentiated as if it is the soft sample in autograd
+            dim (int):
+                a dimension along which softmax will be computed. Default: -1.
 
         Returns:
-                Sampled tensor of same shape as logits from the Gumbel-Softmax distribution.
+            Sampled tensor of same shape as logits from the Gumbel-Softmax distribution.
         """
-    
+
         if version.parse(torch.__version__) < version.parse("1.2.0"):
             for i in range(10):
                 transformed = functional.gumbel_softmax(logits, tau=tau, hard=hard,

--- a/ctgan/synthesizer.py
+++ b/ctgan/synthesizer.py
@@ -1,5 +1,6 @@
 import numpy as np
 import torch
+from packaging import version
 from torch import optim
 from torch.nn import functional
 
@@ -7,8 +8,6 @@ from ctgan.conditional import ConditionalGenerator
 from ctgan.models import Discriminator, Generator
 from ctgan.sampler import Sampler
 from ctgan.transformer import DataTransformer
-
-from packaging import version
 
 
 class CTGANSynthesizer(object):
@@ -59,8 +58,8 @@ class CTGANSynthesizer(object):
                 ed = st + item[0]
                 transformed = functional.gumbel_softmax(data[:, st:ed], tau=0.2)
 
-                #Deals with the instability of the gumbel_softmax for older versions of torch
-                #https://drive.google.com/file/d/1AA5wPfZ1kquaRtVruCd6BiYZGcDeNxyP/view?usp=sharing
+                # Deals with the instability of the gumbel_softmax for older versions of torch
+                # https://drive.google.com/file/d/1AA5wPfZ1kquaRtVruCd6BiYZGcDeNxyP/view?usp=sharing
                 if version.parse(torch.__version__) < version.parse("1.2.0"):
                     for i in range(10):
                         if torch.isnan(transformed).any():
@@ -69,7 +68,6 @@ class CTGANSynthesizer(object):
                             break
                     else:
                         raise ValueError("gumbel_softmax returning NaN.")
-
 
                 data_t.append(transformed)
                 st = ed

--- a/ctgan/synthesizer.py
+++ b/ctgan/synthesizer.py
@@ -55,7 +55,10 @@ class CTGANSynthesizer(object):
                 st = ed
             elif item[1] == 'softmax':
                 ed = st + item[0]
-                data_t.append(functional.gumbel_softmax(data[:, st:ed], tau=0.2))
+                weights = functional.gumbel_softmax(data[:, st:ed], tau=0.2)
+                while np.isnan(torch.sum(weights).cpu().detach().numpy()):
+                    weights = functional.gumbel_softmax(data[:, st:ed], tau=0.2)
+                data_t.append(weights)
                 st = ed
             else:
                 assert 0

--- a/ctgan/synthesizer.py
+++ b/ctgan/synthesizer.py
@@ -46,7 +46,8 @@ class CTGANSynthesizer(object):
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         self.trained_epoches = 0
 
-    def _gumbel_softmax(self, logits, tau=1, hard=False, eps=1e-10, dim=-1):
+    @staticmethod
+    def _gumbel_softmax(logits, tau=1, hard=False, eps=1e-10, dim=-1):
         """Deals with the instability of the gumbel_softmax for older versions of torch
            https://drive.google.com/file/d/1AA5wPfZ1kquaRtVruCd6BiYZGcDeNxyP/view?usp=sharing
 
@@ -60,7 +61,7 @@ class CTGANSynthesizer(object):
         Returns:
                 Sampled tensor of same shape as logits from the Gumbel-Softmax distribution.
         """
-
+    
         if version.parse(torch.__version__) < version.parse("1.2.0"):
             for i in range(10):
                 transformed = functional.gumbel_softmax(logits, tau=tau, hard=hard,

--- a/ctgan/synthesizer.py
+++ b/ctgan/synthesizer.py
@@ -50,8 +50,8 @@ class CTGANSynthesizer(object):
     def _gumbel_softmax(logits, tau=1, hard=False, eps=1e-10, dim=-1):
         """Deals with the instability of the gumbel_softmax for older versions of torch.
 
-           For more details about the issue: 
-           https://drive.google.com/file/d/1AA5wPfZ1kquaRtVruCd6BiYZGcDeNxyP/view?usp=sharing
+        For more details about the issue:
+        https://drive.google.com/file/d/1AA5wPfZ1kquaRtVruCd6BiYZGcDeNxyP/view?usp=sharing
 
         Args:
             logits:

--- a/ctgan/synthesizer.py
+++ b/ctgan/synthesizer.py
@@ -45,21 +45,31 @@ class CTGANSynthesizer(object):
         self.batch_size = batch_size
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         self.trained_epoches = 0
-    
+
     def _gumbel_softmax(self, logits, tau=1, hard=False, eps=1e-10, dim=-1):
-        # Deals with the instability of the gumbel_softmax for older versions of torch
-        # https://drive.google.com/file/d/1AA5wPfZ1kquaRtVruCd6BiYZGcDeNxyP/view?usp=sharing
-        transformed = functional.gumbel_softmax(logits, tau=tau, hard=hard, eps=eps, dim=dim)
+        """Deals with the instability of the gumbel_softmax for older versions of torch
+           https://drive.google.com/file/d/1AA5wPfZ1kquaRtVruCd6BiYZGcDeNxyP/view?usp=sharing
+
+        Args:
+            logits: […, num_features] unnormalized log probabilities
+            tau: non-negative scalar temperature
+            hard: if True, the returned samples will be discretized as one-hot vectors,
+                  but will be differentiated as if it is the soft sample in autograd
+            dim (int): A dimension along which softmax will be computed. Default: -1.
+
+        Returns:
+                Sampled tensor of same shape as logits from the Gumbel-Softmax distribution.
+        """
+
         if version.parse(torch.__version__) < version.parse("1.2.0"):
             for i in range(10):
-                if torch.isnan(transformed).any():
-                    transformed = functional.gumbel_softmax(logits, tau=0.2)
-                else:
-                    break
-            else:
-                raise ValueError("gumbel_softmax returning NaN.")
-        
-        return transformed
+                transformed = functional.gumbel_softmax(logits, tau=tau, hard=hard,
+                                                        eps=eps, dim=dim)
+                if not torch.isnan(transformed).any():
+                    return transformed
+            raise ValueError("gumbel_softmax returning NaN.")
+
+        return functional.gumbel_softmax(logits, tau=tau, hard=hard, eps=eps, dim=dim)
 
     def _apply_activate(self, data):
         data_t = []


### PR DESCRIPTION
When using versions of torch older than 1.2.0, the gumbel_softmax function is unstable, sometimes returning NaN values and messing up the rest of the training process: pytorch/pytorch#22442.

This PR bypasses this issue by recomputing the gumbel_softmax several times until it produces a non-NaN value.

For further information, look [here](https://drive.google.com/file/d/1AA5wPfZ1kquaRtVruCd6BiYZGcDeNxyP/view?usp=sharing).

This resolves #73 and resolves #47.