### PR TITLE
Expose hyperparameters

### DIFF
--- a/ctgan/synthesizers/ctgan.py
+++ b/ctgan/synthesizers/ctgan.py
@@ -122,6 +122,13 @@ class CTGANSynthesizer(BaseSynthesizer):
             Whether to have print statements for progress results. Defaults to ``False``.
         epochs (int):
             Number of training epochs. Defaults to 300.
+        pac (int):
+            Number of samples to group together when applying the discriminator.
+            Defaults to 10.
+        cuda (bool):
+            Whether to attempt to use cuda for GPU computation.
+            If this is False or CUDA is not available, CPU will be used.
+            Defaults to ``True``.
     """
 
     def __init__(self, embedding_dim=128, generator_dim=(256, 256), discriminator_dim=(256, 256),
@@ -157,7 +164,6 @@ class CTGANSynthesizer(BaseSynthesizer):
 
         self._device = torch.device(device)
 
-        #attributes that look questionable (gotta change set_device if we keep this)
         self._transformer = None
         self._data_sampler = None
         self._generator = None
@@ -451,7 +457,6 @@ class CTGANSynthesizer(BaseSynthesizer):
                 c1 = torch.from_numpy(c1).to(self._device)
                 fakez = torch.cat([fakez, c1], dim=1)
 
-            print(fakez)
             fake = self._generator(fakez)
             fakeact = self._apply_activate(fake)
             data.append(fakeact.detach().cpu().numpy())
@@ -463,7 +468,7 @@ class CTGANSynthesizer(BaseSynthesizer):
 
     def set_device(self, device):
         self._device = device
-        if hasattr(self, '_generator'):
+        if self._generator is not None:
             self._generator.to(self._device)
-        if hasattr(self, '_discriminator'):
+        if self._discriminator is not None:
             self._discriminator.to(self._device)

--- a/ctgan/synthesizers/ctgan.py
+++ b/ctgan/synthesizers/ctgan.py
@@ -168,8 +168,6 @@ class CTGANSynthesizer(BaseSynthesizer):
         self._data_sampler = None
         self._generator = None
         self._discriminator = None
-        _optimizerG = None
-        _optimizerD = None
 
     @staticmethod
     def _gumbel_softmax(logits, tau=1, hard=False, eps=1e-10, dim=-1):

--- a/ctgan/synthesizers/ctgan.py
+++ b/ctgan/synthesizers/ctgan.py
@@ -167,7 +167,6 @@ class CTGANSynthesizer(BaseSynthesizer):
         self._transformer = None
         self._data_sampler = None
         self._generator = None
-        self._discriminator = None
 
     @staticmethod
     def _gumbel_softmax(logits, tau=1, hard=False, eps=1e-10, dim=-1):
@@ -322,7 +321,7 @@ class CTGANSynthesizer(BaseSynthesizer):
         )
 
         _optimizerD = optim.Adam(
-            self._discriminator.parameters(), lr=self._discriminator_lr,
+            _discriminator.parameters(), lr=self._discriminator_lr,
             betas=(0.5, 0.9), weight_decay=self._discriminator_decay
         )
 

--- a/ctgan/synthesizers/tvae.py
+++ b/ctgan/synthesizers/tvae.py
@@ -82,7 +82,9 @@ class TVAESynthesizer(BaseSynthesizer):
         decompress_dims=(128, 128),
         l2scale=1e-5,
         batch_size=500,
-        epochs=300
+        epochs=300,
+        loss_factor=2,
+        cuda=True
     ):
 
         self.embedding_dim = embedding_dim
@@ -91,10 +93,17 @@ class TVAESynthesizer(BaseSynthesizer):
 
         self.l2scale = l2scale
         self.batch_size = batch_size
-        self.loss_factor = 2
+        self.loss_factor = loss_factor
         self.epochs = epochs
 
-        self._device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        if not cuda or not torch.cuda.is_available():
+            device = 'cpu'
+        elif isinstance(cuda, str):
+            device = cuda
+        else:
+            device = 'cuda'
+
+        self._device = torch.device(device)
 
     def fit(self, train_data, discrete_columns=tuple()):
         self.transformer = DataTransformer()


### PR DESCRIPTION
The goal of this PR is two-fold: to expose all hyperparameters which the user may find useful, both in CTGAN and TVAE, as well as to reorganize the code so that all attributes are defined inside `__init__`, for better readability.