### PR TITLE
Verbosity enhancement

### DIFF
--- a/tests/integration/test_ctgan.py
+++ b/tests/integration/test_ctgan.py
@@ -184,3 +184,14 @@ def test_wrong_sampling_conditions():
 
     with pytest.raises(ValueError):
         ctgan.sample(1, 'discrete', "d")
+
+
+def test_verbosity():
+    data = pd.DataFrame({
+        'continuous': np.random.random(100),
+        'discrete': np.random.choice(['a', 'b', 'c'], 100)
+    })
+    discrete_columns = ['discrete']
+
+    ctgan = CTGANSynthesizer(epochs=1, verbose=1)
+    ctgan.fit(data, discrete_columns)


### PR DESCRIPTION
This PR is related to issue #15, with three updates:

1. consider `verbose` init param in `CTGAN` as a frequence, i.e. progress results will be printed every `verbose` epochs
2. print training duration in progress results
3. print device used if `verbose` is not 0.