### PR TITLE
Example for #179 using progressbar

### DIFF
--- a/ctgan/synthesizers/ctgan.py
+++ b/ctgan/synthesizers/ctgan.py
@@ -6,6 +6,7 @@ import torch
 from packaging import version
 from torch import optim
 from torch.nn import BatchNorm1d, Dropout, LeakyReLU, Linear, Module, ReLU, Sequential, functional
+from tqdm import tqdm
 
 from ctgan.data_sampler import DataSampler
 from ctgan.data_transformer import DataTransformer
@@ -329,9 +330,8 @@ class CTGANSynthesizer(BaseSynthesizer):
 
         steps_per_epoch = max(len(train_data) // self._batch_size, 1)
         for i in range(epochs):
-            for id_ in range(steps_per_epoch):
-
-                for n in range(self._discriminator_steps):
+            for _ in tqdm(range(steps_per_epoch), unit="batch", disable=not self._verbose):
+                for _ in range(self._discriminator_steps):
                     fakez = torch.normal(mean=mean, std=std)
 
                     condvec = self._data_sampler.sample_condvec(self._batch_size)

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ install_requires = [
     'torch>=1.4,<2',
     'torchvision>=0.5.0,<1',
     'rdt>=0.5.0,<0.6',
+    'tqdm >=4.62.3'
 ]
 
 setup_requires = [


### PR DESCRIPTION
This is an example usage of `tqdm` progressbar.

- It uses the verbose parameter from CTGAN to decide if a progressbar should be shown.
- It adds a verbosity parameter to TVAE.
  - logging loss after each epoch when `True`
  - creating a progressbar when `True`
- Adds `tqdm` to required pip packages