### PR TITLE
Add `flake8-builtins`

### DIFF
--- a/ctgan/data_sampler.py
+++ b/ctgan/data_sampler.py
@@ -146,7 +146,7 @@ class DataSampler(object):
 
     def generate_cond_from_condition_column_info(self, condition_info, batch):
         vec = np.zeros((batch, self._n_categories), dtype='float32')
-        id = self._discrete_column_matrix_st[condition_info["discrete_column_id"]
-                                             ] + condition_info["value_id"]
-        vec[:, id] = 1
+        id_ = self._discrete_column_matrix_st[condition_info["discrete_column_id"]
+                                              ] + condition_info["value_id"]
+        vec[:, id_] = 1
         return vec

--- a/ctgan/data_sampler.py
+++ b/ctgan/data_sampler.py
@@ -146,7 +146,7 @@ class DataSampler(object):
 
     def generate_cond_from_condition_column_info(self, condition_info, batch):
         vec = np.zeros((batch, self._n_categories), dtype='float32')
-        id = self._discrete_column_matrix_st[condition_info['discrete_column_id']
-        id += condition_info['value_id']
-        vec[:, id] = 1
+        id_ = self._discrete_column_matrix_st[condition_info['discrete_column_id']]
+        id_ += condition_info['value_id']
+        vec[:, id_] = 1
         return vec

--- a/ctgan/synthesizers/ctgan.py
+++ b/ctgan/synthesizers/ctgan.py
@@ -48,8 +48,8 @@ class Discriminator(Module):
 
         return gradient_penalty
 
-    def forward(self, input):
-        assert input.size()[0] % self.pac == 0
+    def forward(self, input_):
+        assert input_.size()[0] % self.pac == 0
         return self.seq(input.view(-1, self.pacdim))
 
 
@@ -61,11 +61,11 @@ class Residual(Module):
         self.bn = BatchNorm1d(o)
         self.relu = ReLU()
 
-    def forward(self, input):
-        out = self.fc(input)
+    def forward(self, input_):
+        out = self.fc(input_)
         out = self.bn(out)
         out = self.relu(out)
-        return torch.cat([out, input], dim=1)
+        return torch.cat([out, input_], dim=1)
 
 
 class Generator(Module):
@@ -80,8 +80,8 @@ class Generator(Module):
         seq.append(Linear(dim, data_dim))
         self.seq = Sequential(*seq)
 
-    def forward(self, input):
-        data = self.seq(input)
+    def forward(self, input_):
+        data = self.seq(input_)
         return data
 
 

--- a/ctgan/synthesizers/ctgan.py
+++ b/ctgan/synthesizers/ctgan.py
@@ -50,7 +50,7 @@ class Discriminator(Module):
 
     def forward(self, input_):
         assert input_.size()[0] % self.pac == 0
-        return self.seq(input.view(-1, self.pacdim))
+        return self.seq(input_.view(-1, self.pacdim))
 
 
 class Residual(Module):

--- a/ctgan/synthesizers/tvae.py
+++ b/ctgan/synthesizers/tvae.py
@@ -24,8 +24,8 @@ class Encoder(Module):
         self.fc1 = Linear(dim, embedding_dim)
         self.fc2 = Linear(dim, embedding_dim)
 
-    def forward(self, input):
-        feature = self.seq(input)
+    def forward(self, input_):
+        feature = self.seq(input_)
         mu = self.fc1(feature)
         logvar = self.fc2(feature)
         std = torch.exp(0.5 * logvar)
@@ -45,8 +45,8 @@ class Decoder(Module):
         self.seq = Sequential(*seq)
         self.sigma = Parameter(torch.ones(data_dim) * 0.1)
 
-    def forward(self, input):
-        return self.seq(input), self.sigma
+    def forward(self, input_):
+        return self.seq(input_), self.sigma
 
 
 def loss_function(recon_x, x, sigmas, mu, logvar, output_info, factor):

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,8 @@ universal = 1
 [flake8]
 max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
-ignore = W503
+extend-ignore = W503,
+	VNE001  # Single letter variable names are not allowed
 
 [isort]
 include_trailing_comment = True

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ development_requires = [
     'flake8-absolute-import>=1.0,<2',
     'flake8-eradicate>=1.1.0,<1.2',
     'flake8-builtins>=1.5.3,<1.6',
+    'flake8-variables-names>=0.0.4,<0.1',
 
     # fix style issues
     'autoflake>=1.1,<2',

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ development_requires = [
     'flake8-mutable>=1.2.0,<1.3',
     'flake8-absolute-import>=1.0,<2',
     'flake8-eradicate>=1.1.0,<1.2',
+    'flake8-builtins>=1.5.3,<1.6',
 
     # fix style issues
     'autoflake>=1.1,<2',

--- a/tests/integration/synthesizer/test_ctgan.py
+++ b/tests/integration/synthesizer/test_ctgan.py
@@ -154,7 +154,7 @@ def test_wrong_discrete_columns_dataframe():
     discrete_columns = ['b', 'c']
 
     ctgan = CTGANSynthesizer(epochs=1)
-    with pytest.raises(ValueError, match='Invalid columns found: {\'.*\', \'.*\'}'):
+    with pytest.raises(ValueError, match="Invalid columns found: {'.*', '.*'}"):
         ctgan.fit(data, discrete_columns)
 
 
@@ -179,7 +179,7 @@ def test_wrong_sampling_conditions():
     ctgan = CTGANSynthesizer(epochs=1)
     ctgan.fit(data, discrete_columns)
 
-    with pytest.raises(ValueError, match='The column_name `cardinal` doesn\'t exist in the data.'):
+    with pytest.raises(ValueError, match="The column_name `cardinal` doesn't exist in the data."):
         ctgan.sample(1, 'cardinal', "doesn't matter")
 
     with pytest.raises(ValueError):  # noqa: RDT currently incorrectly raises a tuple instead of a string


### PR DESCRIPTION
As part of #176, added the `flake8-builtins` and `flake8-variables-names` addons and adapted our code to follow this style check. I added both together since they both complain about the variable names shadowing builtin variables.

