### PR TITLE
Track best model in epochs

### DIFF
--- a/ctgan/synthesizers/base.py
+++ b/ctgan/synthesizers/base.py
@@ -7,6 +7,12 @@ class BaseSynthesizer:
     This should contain the save/load methods.
     """
 
+    def __init__(self):
+        self._best_model = None
+
+    def get_best(self):
+        return self._best_model
+
     def save(self, path):
         device_backup = self._device
         self.set_device(torch.device("cpu"))

--- a/ctgan/synthesizers/ctgan.py
+++ b/ctgan/synthesizers/ctgan.py
@@ -267,7 +267,7 @@ class CTGANSynthesizer(BaseSynthesizer):
         if invalid_columns:
             raise ValueError('Invalid columns found: {}'.format(invalid_columns))
 
-    def fit(self, train_data, discrete_columns=tuple(), epochs=None):
+    def fit(self, train_data, discrete_columns=tuple(), epochs=None, save_best=False):
         """Fit the CTGAN Synthesizer models to the training data.
 
         Args:
@@ -278,6 +278,8 @@ class CTGANSynthesizer(BaseSynthesizer):
                 Vector. If ``train_data`` is a Numpy array, this list should
                 contain the integer indices of the columns. Otherwise, if it is
                 a ``pandas.DataFrame``, this list should contain the column names.
+            save_best (bool):
+                If True, the model with the lowest loss will be saved to the object.
         """
         self._validate_discrete_columns(train_data, discrete_columns)
 
@@ -326,11 +328,11 @@ class CTGANSynthesizer(BaseSynthesizer):
 
         mean = torch.zeros(self._batch_size, self._embedding_dim, device=self._device)
         std = mean + 1
-
+        best_loss = float("inf")
         steps_per_epoch = max(len(train_data) // self._batch_size, 1)
         for i in range(epochs):
+            epoch_loss = 0
             for id_ in range(steps_per_epoch):
-
                 for n in range(self._discriminator_steps):
                     fakez = torch.normal(mean=mean, std=std)
 
@@ -374,6 +376,8 @@ class CTGANSynthesizer(BaseSynthesizer):
                     loss_d.backward()
                     optimizerD.step()
 
+                    epoch_loss += abs(loss_d.detach().clone().item())
+
                 fakez = torch.normal(mean=mean, std=std)
                 condvec = self._data_sampler.sample_condvec(self._batch_size)
 
@@ -404,6 +408,11 @@ class CTGANSynthesizer(BaseSynthesizer):
                 loss_g.backward()
                 optimizerG.step()
 
+                epoch_loss += abs(loss_g.detach().clone().item())
+
+            if save_best and epoch_loss < best_loss:
+                best_loss = epoch_loss
+                self._best_model = self
             if self._verbose:
                 print(f"Epoch {i+1}, Loss G: {loss_g.detach().cpu(): .4f}, "
                       f"Loss D: {loss_d.detach().cpu(): .4f}",

--- a/tests/integration/synthesizer/test_ctgan.py
+++ b/tests/integration/synthesizer/test_ctgan.py
@@ -147,6 +147,40 @@ def test_save_load():
     assert set(sampled['discrete'].unique()) == {'a', 'b', 'c'}
 
 
+def test_get_best():
+    data = pd.DataFrame({
+        'continuous': np.random.random(100),
+        'discrete': np.random.choice(['a', 'b', 'c'], 100)
+    })
+    discrete_columns = ['discrete']
+
+    ctgan = CTGANSynthesizer(epochs=1)
+    ctgan.fit(data, discrete_columns, save_best=True)
+
+    sampled = ctgan.get_best().sample(1000)
+    assert set(sampled.columns) == {'continuous', 'discrete'}
+    assert set(sampled['discrete'].unique()) == {'a', 'b', 'c'}
+
+
+def test_save_load_best():
+    data = pd.DataFrame({
+        'continuous': np.random.random(100),
+        'discrete': np.random.choice(['a', 'b', 'c'], 100)
+    })
+    discrete_columns = ['discrete']
+
+    ctgan = CTGANSynthesizer(epochs=1)
+    ctgan.fit(data, discrete_columns, save_best=True)
+
+    with tf.TemporaryDirectory() as temporary_directory:
+        ctgan.get_best().save(temporary_directory + "test_best.pkl")
+        ctgan = CTGANSynthesizer.load(temporary_directory + "test_best.pkl")
+
+    sampled = ctgan.sample(1000)
+    assert set(sampled.columns) == {'continuous', 'discrete'}
+    assert set(sampled['discrete'].unique()) == {'a', 'b', 'c'}
+
+
 def test_wrong_discrete_columns_dataframe():
     data = pd.DataFrame({
         'discrete': ['a', 'b']

--- a/tests/integration/synthesizer/test_tvae.py
+++ b/tests/integration/synthesizer/test_tvae.py
@@ -9,6 +9,9 @@ but correctness of the data values and the internal behavior of the
 model are not checked.
 """
 
+import tempfile as tf
+
+import numpy as np
 import pandas as pd
 from sklearn import datasets
 
@@ -90,3 +93,37 @@ def test_loss_function():
     avg_error = error / num_samples
 
     assert avg_error < 400
+
+
+def test_get_best():
+    data = pd.DataFrame({
+        'continuous': np.random.random(100),
+        'discrete': np.random.choice(['a', 'b', 'c'], 100)
+    })
+    discrete_columns = ['discrete']
+
+    tvae = TVAESynthesizer(epochs=1)
+    tvae.fit(data, discrete_columns, save_best=True)
+
+    sampled = tvae.get_best().sample(1000)
+    assert set(sampled.columns) == {'continuous', 'discrete'}
+    assert set(sampled['discrete'].unique()) == {'a', 'b', 'c'}
+
+
+def test_save_load_best():
+    data = pd.DataFrame({
+        'continuous': np.random.random(100),
+        'discrete': np.random.choice(['a', 'b', 'c'], 100)
+    })
+    discrete_columns = ['discrete']
+
+    tvae = TVAESynthesizer(epochs=1)
+    tvae.fit(data, discrete_columns, save_best=True)
+
+    with tf.TemporaryDirectory() as temporary_directory:
+        tvae.get_best().save(temporary_directory + "test_best.pkl")
+        tvae = TVAESynthesizer.load(temporary_directory + "test_best.pkl")
+
+    sampled = tvae.sample(1000)
+    assert set(sampled.columns) == {'continuous', 'discrete'}
+    assert set(sampled['discrete'].unique()) == {'a', 'b', 'c'}


### PR DESCRIPTION
Implements tracking model with best loss over epochs and saving the model to an attribute in the object if specified by the user.
Best model can be retrieved by calling `get_best()`, but will return `None` if `save_best` parameter is not set to `True` when calling `fit()`.


- if `save_best` is true save best model in synthesizer object attribute (`_best_model`)
- add `get_best()` function:
  - returns best_model or None if not saved
- combine CTGAN Discriminator and Generator loss for best loss decision
  - use absolute values as loss can be negative
- TVAE loss is used directly
- losses are detached from computation graph and cloned