### PR TITLE
🐛update self.decoder with correct variable name

### DIFF
--- a/ctgan/synthesizers/tvae.py
+++ b/ctgan/synthesizers/tvae.py
@@ -153,7 +153,7 @@ class TVAESynthesizer(BaseSynthesizer):
 
         data_dim = self.transformer.output_dimensions
         encoder = Encoder(data_dim, self.compress_dims, self.embedding_dim).to(self._device)
-        self.decoder = Decoder(self.embedding_dim, self.compress_dims, data_dim).to(self._device)
+        self.decoder = Decoder(self.embedding_dim, self.decompress_dims, data_dim).to(self._device)
         optimizerAE = Adam(
             list(encoder.parameters()) + list(self.decoder.parameters()),
             weight_decay=self.l2scale)


### PR DESCRIPTION
Minor fix: the decoder is instantiated with compress_dims instead of decompress_dims, this PR will fix that and ensure the decoder is instantiated with the correct user-defined dimensions.