### PR TITLE
Fix set random seed with none

### DIFF
--- a/ctgan/synthesizers/base.py
+++ b/ctgan/synthesizers/base.py
@@ -82,11 +82,13 @@ class BaseSynthesizer:
         """Set the random state.
 
         Args:
-            random_state (tuple or int):
+            random_state (int, tuple, or None):
                 Either a tuple containing the (numpy.random.RandomState, torch.Generator)
                 or an int representing the random seed to use for both random states.
         """
-        if isinstance(random_state, int):
+        if random_state is None:
+            self.random_state = random_state
+        elif isinstance(random_state, int):
             self.random_states = (
                 np.random.RandomState(seed=random_state),
                 torch.Generator().manual_seed(random_state),

--- a/tests/unit/synthesizer/test_base.py
+++ b/tests/unit/synthesizer/test_base.py
@@ -97,3 +97,14 @@ class TestBaseSynthesizer:
         assert isinstance(instance.random_states, tuple)
         assert isinstance(instance.random_states[0], np.random.RandomState)
         assert isinstance(instance.random_states[1], torch.Generator)
+
+    def test_set_random_state_with_none(self):
+        """Test ``set_random_state`` with None."""
+        # Setup
+        instance = BaseSynthesizer()
+
+        # Run
+        instance.set_random_state(None)
+
+        # Assert
+        assert instance.random_states is None


### PR DESCRIPTION
Allow `None` to be passed into `set_random_seed`