### PR TITLE
robustness fix, when data have less rows than the default number of cl…

### DIFF
--- a/ctgan/data_transformer.py
+++ b/ctgan/data_transformer.py
@@ -45,7 +45,7 @@ class DataTransformer(object):
                 A ``ColumnTransformInfo`` object.
         """
         column_name = data.columns[0]
-        gm = BayesGMMTransformer()
+        gm = BayesGMMTransformer(max_clusters=min(len(data), 10))
         gm.fit(data, [column_name])
         num_components = sum(gm.valid_component_indicator)
 

--- a/tests/unit/test_data_transformer.py
+++ b/tests/unit/test_data_transformer.py
@@ -54,7 +54,7 @@ class TestDataTransformer(TestCase):
         assert info.output_info[1].activation_fn == 'softmax'
 
     @patch('ctgan.data_transformer.BayesGMMTransformer')
-    def test__fit_continuous_max_clusters(MockBGM):
+    def test__fit_continuous_max_clusters(self, MockBGM):
         """Test ``_fit_continuous`` with data that has less than 10 rows.
 
         Expect that a ``BayesGMMTransformer`` is created with the max number of clusters

--- a/tests/unit/test_data_transformer.py
+++ b/tests/unit/test_data_transformer.py
@@ -52,7 +52,7 @@ class TestDataTransformer(TestCase):
         assert info.output_info[0].activation_fn == 'tanh'
         assert info.output_info[1].dim == 2
         assert info.output_info[1].activation_fn == 'softmax'
-    
+
     @patch('ctgan.data_transformer.BayesGMMTransformer')
     def test__fit_continuous_max_clusters(MockBGM):
         """Test ``_fit_continuous`` with data that has less than 10 rows.
@@ -62,7 +62,7 @@ class TestDataTransformer(TestCase):
 
         Input:
         - Data with less than 10 rows.
-        
+
         Side Effects:
         - A ``BayesGMMTransformer`` is created with the max number of clusters set to the
           length of the data.
@@ -70,7 +70,7 @@ class TestDataTransformer(TestCase):
         # Setup
         data = pd.DataFrame(np.random.normal((7, 1)), columns=['column'])
         transformer = DataTransformer()
-    
+
         # Run
         transformer._fit_continuous(data)
 

--- a/tests/unit/test_data_transformer.py
+++ b/tests/unit/test_data_transformer.py
@@ -52,6 +52,30 @@ class TestDataTransformer(TestCase):
         assert info.output_info[0].activation_fn == 'tanh'
         assert info.output_info[1].dim == 2
         assert info.output_info[1].activation_fn == 'softmax'
+    
+    @patch('ctgan.data_transformer.BayesGMMTransformer')
+    def test__fit_continuous_max_clusters(MockBGM):
+        """Test ``_fit_continuous`` with data that has less than 10 rows.
+
+        Expect that a ``BayesGMMTransformer`` is created with the max number of clusters
+        set to the length of the data.
+
+        Input:
+        - Data with less than 10 rows.
+        
+        Side Effects:
+        - A ``BayesGMMTransformer`` is created with the max number of clusters set to the
+          length of the data.
+        """
+        # Setup
+        data = pd.DataFrame(np.random.normal((7, 1)), columns=['column'])
+        transformer = DataTransformer()
+    
+        # Run
+        transformer._fit_continuous(data)
+
+        # Assert
+        MockBGM.assert_called_once_with(max_clusters=len(data))
 
     @patch('ctgan.data_transformer.OneHotEncodingTransformer')
     def test___fit_discrete(self, MockOHE):


### PR DESCRIPTION
If the input data frame has less rows than the default `max_clusters` of the numerical transformer then an exception is raised with the following type of error:


```console
  File "/Users/romainegele/Documents/Argonne/deephyper/deephyper/search/hps/_ambs.py", line 416, in fit_generative_model
    model.fit(req_df)
  File "/Users/romainegele/Documents/Argonne/deephyper-sdv/sdv/tabular/base.py", line 157, in fit
    self._fit(transformed)
  File "/Users/romainegele/Documents/Argonne/deephyper-sdv/sdv/tabular/ctgan.py", line 57, in _fit
    self._model.fit(
  File "/Users/romainegele/Documents/Argonne/deephyper-CTGAN/ctgan/synthesizers/base.py", line 49, in wrapper
    return function(self, *args, **kwargs)
  File "/Users/romainegele/Documents/Argonne/deephyper-CTGAN/ctgan/synthesizers/tvae.py", line 150, in fit
    self.transformer.fit(train_data, discrete_columns)
  File "/Users/romainegele/Documents/Argonne/deephyper-CTGAN/ctgan/data_transformer.py", line 103, in fit
    column_transform_info = self._fit_continuous(raw_data[[column_name]])
  File "/Users/romainegele/Documents/Argonne/deephyper-CTGAN/ctgan/data_transformer.py", line 49, in _fit_continuous
    gm.fit(data, [column_name])
  File "/Users/romainegele/miniforge3/envs/dh-arm/lib/python3.9/site-packages/rdt/transformers/base.py", line 186, in fit
    self._fit(columns_data)
  File "/Users/romainegele/miniforge3/envs/dh-arm/lib/python3.9/site-packages/rdt/transformers/numerical.py", line 599, in _fit
    self._bgm_transformer.fit(data.reshape(-1, 1))
  File "/Users/romainegele/miniforge3/envs/dh-arm/lib/python3.9/site-packages/sklearn/mixture/_base.py", line 198, in fit
    self.fit_predict(X, y)
  File "/Users/romainegele/miniforge3/envs/dh-arm/lib/python3.9/site-packages/sklearn/mixture/_base.py", line 230, in fit_predict
    raise ValueError(
ValueError: Expected n_samples >= n_components but got n_components = 10, n_samples = 7
```

This can be resolved by clipping the default `max_clusters` by the `min(10, len(data))`.