### PR TITLE
Update slack invite link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ CTGAN is a collection of Deep Learning based Synthetic Data Generators for s
 [License]: https://github.com/sdv-dev/CTGAN/blob/master/LICENSE
 [Development Status]: https://pypi.org/search/?c=Development+Status+%3A%3A+2+-+Pre-Alpha
 [Slack Logo]: https://github.com/sdv-dev/SDV/blob/master/docs/images/slack.png
-[Community]: https://join.slack.com/t/sdv-space/shared_invite/zt-gdsfcb5w-0QQpFMVoyB2Yd6SRiMplcw
+[Community]: https://bit.ly/sdv-slack-invite
 [MyBinder Logo]: https://github.com/sdv-dev/SDV/blob/master/docs/images/mybinder.png
 [Tutorials]: https://mybinder.org/v2/gh/sdv-dev/SDV/master?filepath=tutorials
 


### PR DESCRIPTION
Update the current slack invite link to a new one since the old one expired.