### PR TITLE
Add parallelization of data transformation

### DIFF
--- a/ctgan/data_transformer.py
+++ b/ctgan/data_transformer.py
@@ -1,7 +1,6 @@
 """DataTransformer module."""
 
 from collections import namedtuple
-from multiprocessing import cpu_count
 
 import numpy as np
 import pandas as pd
@@ -160,7 +159,7 @@ class DataTransformer(object):
                 process = delayed(self._transform_discrete)(column_transform_info, data)
             processes.append(process)
 
-        return Parallel(n_jobs=cpu_count())(processes)
+        return Parallel(n_jobs=-1)(processes)
 
     def transform(self, raw_data):
         """Take raw data and output a matrix data."""

--- a/ctgan/data_transformer.py
+++ b/ctgan/data_transformer.py
@@ -8,9 +8,6 @@ from rdt.transformers import ClusterBasedNormalizer, OneHotEncoder
 from joblib import Parallel, delayed
 from multiprocessing import cpu_count
 
-# Speed testing TODO: remove
-from datetime import datetime as dt
-
 SpanInfo = namedtuple('SpanInfo', ['dim', 'activation_fn'])
 ColumnTransformInfo = namedtuple(
     'ColumnTransformInfo', [
@@ -131,15 +128,23 @@ class DataTransformer(object):
         ohe = column_transform_info.transform
         return ohe.transform(data).to_numpy()
 
-    def transform(self, raw_data):
-        """Take raw data and output a matrix data."""
-        
-        if not isinstance(raw_data, pd.DataFrame):
-            column_names = [str(num) for num in range(raw_data.shape[1])]
-            raw_data = pd.DataFrame(raw_data, columns=column_names)
+    def _synchronous_transform(self, raw_data, column_transform_info_list):
+        """Take a Pandas DataFrame and transform columns synchronous. Outputs a list with Numpy arrays."""
+        column_data_list = []
+        for column_transform_info in column_transform_info_list:
+            column_name = column_transform_info.column_name
+            data = raw_data[[column_name]]
+            if column_transform_info.column_type == 'continuous':
+                column_data_list.append(self._transform_continuous(column_transform_info, data))
+            else:
+                column_data_list.append(self._transform_discrete(column_transform_info, data))
+                
+        return column_data_list
 
+    def _parallel_transform(self, raw_data, column_transform_info_list):
+        """Take a Pandas DataFrame and transform columns in parallel. Outputs a list with Numpy arrays."""
         processes = []
-        for column_transform_info in self._column_transform_info_list:
+        for column_transform_info in column_transform_info_list:
             column_name = column_transform_info.column_name
             data = raw_data[[column_name]]
             process = None
@@ -149,7 +154,20 @@ class DataTransformer(object):
                 process = delayed(self._transform_discrete)(column_transform_info, data)
             processes.append(process)
 
-        column_data_list = Parallel(n_jobs=cpu_count())(processes)
+        return Parallel(n_jobs=cpu_count())(processes)
+
+    def transform(self, raw_data):
+        """Take raw data and output a matrix data."""
+        if not isinstance(raw_data, pd.DataFrame):
+            column_names = [str(num) for num in range(raw_data.shape[1])]
+            raw_data = pd.DataFrame(raw_data, columns=column_names)
+
+        # Only use parallelization with larger data sizes. 
+        # Otherwise, the transformation will be slower.
+        if raw_data.shape[0] < 500:
+            column_data_list = self._synchronous_transform(raw_data, self._column_transform_info_list)
+        else:
+            column_data_list = self._parallel_transform(raw_data, self._column_transform_info_list)
 
         return np.concatenate(column_data_list, axis=1).astype(float)
 

--- a/ctgan/synthesizers/base.py
+++ b/ctgan/synthesizers/base.py
@@ -44,6 +44,7 @@ def random_state(function):
         function (Callable):
             The function to wrap around.
     """
+
     def wrapper(self, *args, **kwargs):
         if self.random_states is None:
             return function(self, *args, **kwargs)

--- a/tests/unit/test_data_transformer.py
+++ b/tests/unit/test_data_transformer.py
@@ -278,9 +278,6 @@ class TestDataTransformer(TestCase):
         result = transformer.transform(data)
 
         # Assert
-        transformer._transform_continuous.assert_called_once()
-        transformer._transform_discrete.assert_called_once()
-
         expected = np.array([
             [0.1, 1, 0, 0, 0, 1],
             [0.3, 0, 1, 0, 0, 1],

--- a/tests/unit/test_data_transformer.py
+++ b/tests/unit/test_data_transformer.py
@@ -286,9 +286,10 @@ class TestDataTransformer(TestCase):
         assert (result[:, 4:6] == expected[:, 4:6]).all(), 'discrete'
 
     def test_parallel_sync_transform_same_output(self):
-        """Test ``_parallel_transform`` and ``_synchronous_transform`` on a dataframe with one continuous and one discrete column.
+        """Test ``_parallel_transform`` and ``_synchronous_transform`` on a dataframe.
 
-        The output of ``_parallel_transform`` should be the same as the output of ``_synchronous_transform``.
+        The output of ``_parallel_transform`` should be the same as the output of
+        ``_synchronous_transform``.
 
         Setup:
             - Initialize a ``DataTransformer`` with a ``column_transform_info`` detailing
@@ -340,8 +341,14 @@ class TestDataTransformer(TestCase):
         ])
 
         # Run
-        parallel_result = transformer._parallel_transform(data, transformer._column_transform_info_list)
-        sync_result = transformer._synchronous_transform(data, transformer._column_transform_info_list)
+        parallel_result = transformer._parallel_transform(
+            data,
+            transformer._column_transform_info_list
+        )
+        sync_result = transformer._synchronous_transform(
+            data,
+            transformer._column_transform_info_list
+        )
         parallel_result_np = np.concatenate(parallel_result, axis=1).astype(float)
         sync_result_np = np.concatenate(sync_result, axis=1).astype(float)
 


### PR DESCRIPTION
This PR adds functionality that was requested in #151.

The speed improvement of parallelization is:
Dataframe with shape (1000, 52) = old: 0.8471379280090332 ~ new: 0.4089930057525635 ~ difference: 0.4381449222564697
Dataframe with shape (100000, 52) = old: 73.355579 ~ new: 17.617004199999997 ~ difference: 55.73857480000001

For small datasets, parallelization slows down the transformation. Therefore, for datasets below 500 records, the original synchronous method is used. 

The added unit test confirms that the output of the original transformation is the same as the parallel transformation.