### PR TITLE
Fixed max_clusters bug

### DIFF
--- a/ctgan/data_transformer.py
+++ b/ctgan/data_transformer.py
@@ -46,7 +46,7 @@ class DataTransformer(object):
                 A ``ColumnTransformInfo`` object.
         """
         column_name = data.columns[0]
-        gm = ClusterBasedNormalizer(model_missing_values=True, max_clusters=min(len(data), 10))
+        gm = ClusterBasedNormalizer(model_missing_values=True, max_clusters=min(len(data), self._max_clusters))
         gm.fit(data, column_name)
         num_components = sum(gm.valid_component_indicator)
 


### PR DESCRIPTION
The DataTransformer class allows you to initialize by setting max_clusters, but then when you fit this class o the data it uses the default value 10 at line 49, when it should use self._max_clusters.