### PR TITLE
fixing warnings

### DIFF
--- a/ctgan/data_transformer.py
+++ b/ctgan/data_transformer.py
@@ -109,7 +109,8 @@ class DataTransformer(object):
 
     def _transform_continuous(self, column_transform_info, data):
         column_name = data.columns[0]
-        data[column_name] = data[column_name].to_numpy().flatten()
+        flattened_column = data[column_name].to_numpy().flatten()
+        data = data.assign(**{column_name: flattened_column})
         gm = column_transform_info.transform
         transformed = gm.transform(data)
 
@@ -185,7 +186,7 @@ class DataTransformer(object):
     def _inverse_transform_continuous(self, column_transform_info, column_data, sigmas, st):
         gm = column_transform_info.transform
         data = pd.DataFrame(column_data[:, :2], columns=list(gm.get_output_sdtypes()))
-        data.iloc[:, 1] = np.argmax(column_data[:, 1:], axis=1)
+        data[data.columns[1]] = np.argmax(column_data[:, 1:], axis=1)
         if sigmas is not None:
             selected_normalized_value = np.random.normal(data.iloc[:, 0], sigmas[st])
             data.iloc[:, 0] = selected_normalized_value


### PR DESCRIPTION
resolves #215 
resolves #246

This PR fixes two common warnings that are being raised in `CTGAN`. One is a `SettingWithCopyWarning` that can be fixed by using `assign`. The other is a `FutureWarning` caused because `df.iloc[:, i] = newvals` will change to set items inplace.