### PR TITLE
Recap torch

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,8 @@
 # History
 
-## v0.7.2 - 2023-05-04
+## v0.7.2 - 2023-05-09
 
-This release adds support for Pandas 2.0 and PyTorch 2.0! It also fixes a bug in the `load_demo` function.
+This release adds support for Pandas 2.0! It also fixes a bug in the `load_demo` function.
 
 ### Bugs Fixed
 
@@ -11,7 +11,6 @@ This release adds support for Pandas 2.0 and PyTorch 2.0! It also fixes a bug in
 ### Maintenance
 
 * Remove upper bound for pandas - Issue [#282](https://github.com/sdv-dev/CTGAN/issues/282) by @frances-h
-* Upgrade to torch 2.0 - Issue [#280](https://github.com/sdv-dev/CTGAN/issues/280) by @frances-h
 
 ## v0.7.1 - 2023-02-23
 

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ install_requires = [
     "pandas>=1.1.3;python_version<'3.10'",
     "pandas>=1.3.4;python_version>='3.10'",
     "scikit-learn>=1.1.3,<2;python_version>='3.10'",
-    "torch>=1.8.0;python_version<'3.10'",
-    "torch>=1.11.0;python_version>='3.10'",
+    "torch>=1.8.0,<2;python_version<'3.10'",
+    "torch>=1.11.0,<2;python_version>='3.10'",
     'rdt>=1.3.0,<2.0',
 ]
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration testing subpackage."""

--- a/tests/integration/synthesizer/__init__.py
+++ b/tests/integration/synthesizer/__init__.py
@@ -1,0 +1,1 @@
+"""Subpackage for integration testing of synthesizers."""


### PR DESCRIPTION
This PR 
* Re-caps torch since there are some issues getting the demo to run on torch 2.0
* Attempts to fix fragile tests by adding `__init__.py` to integration tests