### PR TITLE
Remove `model_missing_values` from `ClusterBasedNormalizer` call

### DIFF
--- a/ctgan/data_transformer.py
+++ b/ctgan/data_transformer.py
@@ -46,7 +46,8 @@ class DataTransformer(object):
                 A ``ColumnTransformInfo`` object.
         """
         column_name = data.columns[0]
-        gm = ClusterBasedNormalizer(max_clusters=min(len(data), 10))
+        gm = ClusterBasedNormalizer(
+            missing_value_generation='from_column', max_clusters=min(len(data), 10))
         gm.fit(data, column_name)
         num_components = sum(gm.valid_component_indicator)
 

--- a/ctgan/data_transformer.py
+++ b/ctgan/data_transformer.py
@@ -46,7 +46,7 @@ class DataTransformer(object):
                 A ``ColumnTransformInfo`` object.
         """
         column_name = data.columns[0]
-        gm = ClusterBasedNormalizer(model_missing_values=True, max_clusters=min(len(data), 10))
+        gm = ClusterBasedNormalizer(max_clusters=min(len(data), 10))
         gm.fit(data, column_name)
         num_components = sum(gm.valid_component_indicator)
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "torch>=1.8.0;python_version<'3.10'",
     "torch>=1.11.0;python_version>='3.10' and python_version<'3.11'",
     "torch>=2.0.0;python_version>='3.11'",
-    'rdt>=1.3.0,<2.0',
+    'rdt>=1.6.1,<2.0',
 ]
 
 setup_requires = [

--- a/tests/unit/test_data_transformer.py
+++ b/tests/unit/test_data_transformer.py
@@ -75,7 +75,8 @@ class TestDataTransformer(TestCase):
         transformer._fit_continuous(data)
 
         # Assert
-        MockCBN.assert_called_once_with(max_clusters=len(data))
+        MockCBN.assert_called_once_with(
+            missing_value_generation='from_column', max_clusters=len(data))
 
     @patch('ctgan.data_transformer.OneHotEncoder')
     def test___fit_discrete(self, MockOHE):

--- a/tests/unit/test_data_transformer.py
+++ b/tests/unit/test_data_transformer.py
@@ -75,7 +75,7 @@ class TestDataTransformer(TestCase):
         transformer._fit_continuous(data)
 
         # Assert
-        MockCBN.assert_called_once_with(model_missing_values=True, max_clusters=len(data))
+        MockCBN.assert_called_once_with(max_clusters=len(data))
 
     @patch('ctgan.data_transformer.OneHotEncoder')
     def test___fit_discrete(self, MockOHE):


### PR DESCRIPTION
In RDT's latest version `model_missing_values` is being deprecated.
Resolve [SDV-1544](https://github.com/sdv-dev/SDV/issues/1544)